### PR TITLE
Add optional channel and revision settings to Terraform module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,15 @@
+locals {
+  channel = coalesce(var.channel, var.revision == null ? "latest/edge" : null)
+}
+
 resource "juju_application" "errbot" {
   name  = "errbot"
   model = var.juju_model
 
   charm {
-    name    = "certification-errbot"
-    channel = "latest/edge"
+    name     = "certification-errbot"
+    channel  = local.channel
+    revision = var.revision
   }
 
   config = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -132,3 +132,17 @@ variable "no_proxy" {
   type        = string
   default     = "localhost,127.0.0.1,::1"
 }
+
+variable "channel" {
+  description = "Juju charm channel to use"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "revision" {
+  description = "Revision of the charm to use"
+  type        = number
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
## Summary
- Adds support for optional channel and revision parameters in the Terraform module
- Follows the same pattern as the [testflinger Terraform module](https://github.com/canonical/testflinger/blob/main/server/terraform/main.tf)
- Maintains backward compatibility with existing deployments

## Changes
- Added nullable `channel` and `revision` variables to `terraform/variables.tf`
- Updated `terraform/main.tf` to use dynamic channel selection via a `locals` block
- As an alternative to `latest/edge`, allow providing a specific revision to be set for the charm to deploy