### PR TITLE
Delegate charm channel evaluation logic to external terraform modules.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,14 +1,10 @@
-locals {
-  channel = coalesce(var.channel, var.revision == null ? "latest/edge" : null)
-}
-
 resource "juju_application" "errbot" {
   name  = "errbot"
   model = var.juju_model
 
   charm {
     name     = "certification-errbot"
-    channel  = local.channel
+    channel  = var.channel
     revision = var.revision
   }
 


### PR DESCRIPTION
- Current channel evaluation logic `channel = coalesce(var.channel, var.revision == null ? "latest/edge" : null)`  fails if `var.channel` is null and `var.revision` is not null.
- Currently the logic is split between 2 repositories: this one and [cert-ops](https://github.com/canonical/certification-ops/blob/cece43d5cc0461e3d9142f07067f6f6144b52685/certification-errbot/environments/certification-errbot-production/main.tf#L31). 
- Decision: let the external terraform module decide channel and revision which should be used for charm deployment.