### PR TITLE
Add support for Test Observer API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,4 +43,4 @@ ARTEFACT_FAMILIES=snap,deb
 
 # Test Observer API key (optional)
 # Leave empty to make unauthenticated requests
-TEST_OBSERVER_API_KEY=you_to_api_key
+TEST_OBSERVER_API_KEY=your_test_observer_api_key

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ LLM_MODEL_NAME=
 # Valid families: snap, deb, image, charm (use singular form, no 's')
 # If not set or empty, all families are included
 ARTEFACT_FAMILIES=snap,deb
+
+# Test Observer API key (optional)
+# Leave empty to make unauthenticated requests
+TEST_OBSERVER_API_KEY=you_to_api_key

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -125,6 +125,12 @@ config:
       type: string
       default: "localhost,127.0.0.1,::1"
       description: Resources that we should be able to access bypassing proxy
+    test-observer-api-key:
+      description: |
+        API key for authenticating against the Test Observer API.
+        Leave empty to make unauthenticated requests.
+      type: string
+      default: ""
 
 containers:
   errbot:

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -91,6 +91,7 @@ class ErrbotCharm(ops.CharmBase):
                         "LDAP_BIND_PASSWORD": str(self.model.config["ldap-bind-password"]),
                         "LDAP_SERVER": str(self.model.config["ldap-server"]),
                         "NO_PROXY": str(self.model.config["no-proxy"]),
+                        "TEST_OBSERVER_API_KEY": str(self.model.config["test-observer-api-key"]),
                     },
                 ),
             },

--- a/plugins/certification/artefacts.py
+++ b/plugins/certification/artefacts.py
@@ -12,6 +12,8 @@ from test_observer.api.artefacts.patch_artefact_v1_artefacts_artefact_id_patch i
 )
 from test_observer.client import (
     AuthenticatedClient as AuthTestObserverClient,
+)
+from test_observer.client import (
     Client as TestObserverClient,
 )
 from test_observer.models import ArtefactPatch, ArtefactResponse, ArtefactStatus
@@ -20,14 +22,14 @@ from user_handle_cache import get_user_handle
 logger = logging.getLogger(__name__)
 
 TEST_OBSERVER_BASE_URL = "https://test-observer-api.canonical.com"
-TEST_OBSERVER_API_KEY = os.environ.get("TEST_OBSERVER_API_KEY", "")
 
 
 def _get_test_observer_client():
-    if TEST_OBSERVER_API_KEY:
+    api_key = os.environ.get("TEST_OBSERVER_API_KEY", "")
+    if api_key:
         return AuthTestObserverClient(
             base_url=TEST_OBSERVER_BASE_URL,
-            token=TEST_OBSERVER_API_KEY,
+            token=api_key,
         )
     return TestObserverClient(base_url=TEST_OBSERVER_BASE_URL)
 

--- a/plugins/certification/artefacts.py
+++ b/plugins/certification/artefacts.py
@@ -10,11 +10,27 @@ from test_observer.api.artefacts.get_artefacts_v1_artefacts_get import (
 from test_observer.api.artefacts.patch_artefact_v1_artefacts_artefact_id_patch import (
     sync_detailed as patch_artefact,
 )
-from test_observer.client import Client as TestObserverClient
+from test_observer.client import (
+    AuthenticatedClient as AuthTestObserverClient,
+    Client as TestObserverClient,
+)
 from test_observer.models import ArtefactPatch, ArtefactResponse, ArtefactStatus
 from user_handle_cache import get_user_handle
 
 logger = logging.getLogger(__name__)
+
+TEST_OBSERVER_BASE_URL = "https://test-observer-api.canonical.com"
+TEST_OBSERVER_API_KEY = os.environ.get("TEST_OBSERVER_API_KEY", "")
+
+
+def _get_test_observer_client():
+    if TEST_OBSERVER_API_KEY:
+        return AuthTestObserverClient(
+            base_url=TEST_OBSERVER_BASE_URL,
+            token=TEST_OBSERVER_API_KEY,
+        )
+    return TestObserverClient(base_url=TEST_OBSERVER_BASE_URL)
+
 
 # Get configured artefact families to include (default: all families)
 # Can be configured as comma-separated list, e.g., "snap,deb,image"
@@ -117,9 +133,7 @@ def reply_with_artefacts_summary(target_user, args: List[str]) -> str:
     if len([arg for arg in args if arg.startswith("name-contains:")]) > 1:
         return "You can't use multiple 'name-contains' arguments"
 
-    test_observer_client = TestObserverClient(
-        base_url="https://test-observer-api.canonical.com"
-    )
+    test_observer_client = _get_test_observer_client()
 
     out_msg = ""
 
@@ -297,9 +311,7 @@ def pending_artefacts_by_user_handle() -> Dict[str | None, List[ArtefactResponse
     """
     Get all pending Beta stage artefacts (not approved or failed) by user's Mattermost handle
     """
-    test_observer_client = TestObserverClient(
-        base_url="https://test-observer-api.canonical.com"
-    )
+    test_observer_client = _get_test_observer_client()
 
     with test_observer_client:
         r = get_artefacts(client=test_observer_client)
@@ -436,9 +448,7 @@ def archive_artefact_by_id(artefact_id: int, comment: str = None) -> str:
     Returns:
         Success or error message
     """
-    test_observer_client = TestObserverClient(
-        base_url="https://test-observer-api.canonical.com"
-    )
+    test_observer_client = _get_test_observer_client()
     
     with test_observer_client:
         # Create patch request to archive the artefact

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,5 +33,6 @@ resource "juju_application" "errbot" {
     mattermost-team          = var.mattermost_team
     mattermost-token         = var.mattermost_token
     no-proxy                 = var.no_proxy
+    test-observer-api-key    = var.test_observer_api_key
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -133,6 +133,12 @@ variable "no_proxy" {
   default     = "localhost,127.0.0.1,::1"
 }
 
+variable "test_observer_api_key" {
+  description = "API key for authenticating against the Test Observer API. Leave empty to make unauthenticated requests."
+  type        = string
+  default     = ""
+}
+
 variable "channel" {
   description = "Juju charm channel to use"
   type        = string

--- a/tests/test_artefacts_logic.py
+++ b/tests/test_artefacts_logic.py
@@ -45,6 +45,8 @@ class ArtefactsTestBase(unittest.TestCase):
             bug_link="bug_link",
             comment="test comment 1",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
 
         self.artefact2 = ArtefactResponse(
@@ -73,6 +75,8 @@ class ArtefactsTestBase(unittest.TestCase):
             bug_link="bug_link2",
             comment="test comment 2",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
 
 
@@ -181,6 +185,8 @@ class TestArtefactsSummarySending(ArtefactsTestBase):
             bug_link="bug_link3",
             comment="test comment 3",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_pending_artefacts_by_user_handle.return_value = {
@@ -291,6 +297,8 @@ class TestArtefactsByUserHandle(ArtefactsTestBase):
             bug_link="bug_link10",
             comment="test comment 10",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         # Test with both included and excluded families
@@ -322,6 +330,8 @@ class TestArtefactsByUserHandle(ArtefactsTestBase):
             bug_link="bug_link11",
             comment="test comment 11",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         artefacts_response = [charm_artefact, snap_artefact]
@@ -366,6 +376,8 @@ class TestArtefactsByUserHandle(ArtefactsTestBase):
             bug_link="bug_link10",
             comment="test comment 10",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         artefacts_response = [self.artefact1, charm_artefact]
@@ -556,6 +568,8 @@ class TestReplyWithArtefactsSummary(ArtefactsTestBase):
             bug_link="bug_link3",
             comment="test comment 3",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_get_artefacts.return_value.parsed = [self.artefact1, overdue_artefact]
@@ -616,6 +630,8 @@ class TestReplyWithArtefactsSummary(ArtefactsTestBase):
             bug_link="bug_link10",
             comment="test comment 10",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         charm_artefact = ArtefactResponse(
@@ -644,6 +660,8 @@ class TestReplyWithArtefactsSummary(ArtefactsTestBase):
             bug_link="bug_link11",
             comment="test comment 11",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_get_artefacts.return_value.parsed = [snap_artefact, charm_artefact]
@@ -688,6 +706,8 @@ class TestReplyWithArtefactsSummary(ArtefactsTestBase):
             bug_link="bug_link3",
             comment="test comment 3",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_get_artefacts.return_value.parsed = [unassigned_artefact]
@@ -733,6 +753,8 @@ class TestPendingArtefactsByUserHandle(ArtefactsTestBase):
             bug_link="bug_link3",
             comment="test comment 3",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_get_artefacts.return_value.parsed = [self.artefact1, self.artefact2, approved_artefact]
@@ -788,6 +810,8 @@ class TestPendingArtefactsByUserHandle(ArtefactsTestBase):
             bug_link="bug_link4",
             comment="test comment 4",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_get_artefacts.return_value.parsed = [no_assignee_no_due_date]
@@ -849,6 +873,8 @@ class TestSendArtefactSummaries(ArtefactsTestBase):
             bug_link="bug_link3",
             comment="test comment 3",
             created_at=datetime.now() - timedelta(days=10),
+            reviewers=[],
+            jira_issue=None,
         )
         
         mock_pending_artefacts.return_value = {


### PR DESCRIPTION
This PR resolves [LM-2118](https://warthogs.atlassian.net/browse/LM-2118), as Test Observer API will soon require keys.

[LM-2118]: https://warthogs.atlassian.net/browse/LM-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ