### PR TITLE
Allow packages write

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-and-publish-image:
     runs-on: [self-hosted, linux, xlarge, jammy, x64]
+    permissions:
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fix the permission issue for build-and-publish-image.
https://github.com/canonical/certification-errbot/actions/runs/28949529368/job/85892203130