### PR TITLE
Avoid rejected artifact in the digest if the artifact due date is not set.

### DIFF
--- a/plugins/certification/artefacts.py
+++ b/plugins/certification/artefacts.py
@@ -269,10 +269,8 @@ def artefacts_by_user_handle(
         if artefact.status == ArtefactStatus.APPROVED:
             continue
 
-        if (
-            artefact.status == ArtefactStatus.MARKED_AS_FAILED
-            and artefact.due_date
-            and artefact.due_date < one_week_ago
+        if artefact.status == ArtefactStatus.MARKED_AS_FAILED and (
+            not artefact.due_date or artefact.due_date < one_week_ago
         ):
             continue
 


### PR DESCRIPTION
The rule for the rejected artifact to appear in the digest: due date is set & due date is within 1 week from now.
In this case, if TO returns no due date for the artifact, the rejected artifact will appear in the digest forever.

Changed behavior: if due date is not set -> do not show rejected artifact.